### PR TITLE
Reopen subscriptions after error/close events from subscriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 yarn-error.log
 npm-debug.log
+lerna-debug.log
 .DS_Store
 *.orig
 .vscode/launch.json

--- a/lerna-debug.log
+++ b/lerna-debug.log
@@ -1,9 +1,0 @@
-0 silly argv { _: [ 'run' ],
-0 silly argv   lernaVersion: '3.18.4',
-0 silly argv   '$0': '/usr/local/bin/lerna',
-0 silly argv   script: 'build' }
-1 notice cli v3.18.4
-2 verbose rootPath /Users/kirpichenko/Development/pubsub
-3 error JSONError: Unexpected string in JSON at position 551 while parsing '{  "name": "@join-com/pubsub",  "versi' in packages/pubsub/package.json
-3 error     at module.exports (/Users/kirpichenko/Development/pubsub/node_modules/parse-json/index.js:26:19)
-3 error     at parse (/Users/kirpichenko/Development/pubsub/node_modules/load-json-file/index.js:15:9)

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.26",
+  "version": "0.0.27",
   "packages": [
     "packages/*"
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "npmClient": "yarn"
+  "npmClient": "yarn",
+  "useWorkspaces": true
 }

--- a/packages/datastore-task-executor/package.json
+++ b/packages/datastore-task-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@join-com/datastore-task-executor",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Tracks executing tasks by storing info into Datastore",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/pubsub/__tests__/src/Subscriber.ts
+++ b/packages/pubsub/__tests__/src/Subscriber.ts
@@ -1,4 +1,4 @@
-import { Subscriber, ParsedMessage } from '../../src/Subscriber'
+import { Subscriber, IParsedMessage } from '../../src/Subscriber'
 import * as traceMock from '../../__mocks__/@join-com/node-trace'
 import {
   getClientMock,
@@ -92,7 +92,7 @@ describe('Subscriber', () => {
     })
 
     it('receives parsed data', async () => {
-      let parsedMessage: ParsedMessage<unknown>
+      let parsedMessage: IParsedMessage<unknown>
       subscriber.start(async msg => {
         parsedMessage = msg
       })
@@ -111,6 +111,23 @@ describe('Subscriber', () => {
       await subscriptionMock.receiveMessage(messageMock)
 
       expect(messageMock.nack).toHaveBeenCalled()
+    })
+
+    it('restarts subscription on error', async () => {
+      subscriber.start(Promise.resolve)
+
+      await subscriptionMock.emitError(new Error('boom'))
+
+      expect(subscriptionMock.close).toHaveBeenCalled()
+      expect(subscriptionMock.open).toHaveBeenCalled()
+    })
+
+    it('restarts subscription on close', async () => {
+      subscriber.start(Promise.resolve)
+
+      await subscriptionMock.emitClose()
+
+      expect(subscriptionMock.open).toHaveBeenCalled()
     })
   })
 })

--- a/packages/pubsub/__tests__/src/Subscriber.ts
+++ b/packages/pubsub/__tests__/src/Subscriber.ts
@@ -121,13 +121,5 @@ describe('Subscriber', () => {
       expect(subscriptionMock.close).toHaveBeenCalled()
       expect(subscriptionMock.open).toHaveBeenCalled()
     })
-
-    it('restarts subscription on close', async () => {
-      subscriber.start(Promise.resolve)
-
-      await subscriptionMock.emitClose()
-
-      expect(subscriptionMock.open).toHaveBeenCalled()
-    })
   })
 })

--- a/packages/pubsub/__tests__/support/pubsubMock.ts
+++ b/packages/pubsub/__tests__/support/pubsubMock.ts
@@ -6,13 +6,28 @@ export const getSubscriptionMock = () => {
   return {
     exists: jest.fn(),
     create: jest.fn(),
+    close: jest.fn(),
+    open: jest.fn(),
     on: (event: string, handler: EventHandler) => {
       eventHandlers[event] = handler
     },
     receiveMessage: async (message: MessageMock) => {
-      const handler = eventHandlers['message']
+      const handler = eventHandlers.message
       if (handler) {
         await handler(message)
+      }
+    },
+    emitError: async (err: Error) => {
+      const handler = eventHandlers.error
+      if (handler) {
+        await handler(err)
+      }
+    },
+    emitClose: async () => {
+      const handler = eventHandlers.close
+      if (handler) {
+        // undefined means no error when closing subscriber
+        await handler(undefined)
       }
     }
   }

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -25,7 +25,7 @@
     "pubsub"
   ],
   "dependencies": {
-    "@google-cloud/pubsub": "^1.0.0",
+    "@google-cloud/pubsub": "^1.7.2",
     "@join-com/gcloud-logger-trace": "^0.1.5",
     "@join-com/node-trace": "^0.1.5"
   },

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@join-com/pubsub",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Google Cloud PubSub wrapper",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/pubsub/src/Subscriber.ts
+++ b/packages/pubsub/src/Subscriber.ts
@@ -52,7 +52,6 @@ export class Subscriber<T = unknown> {
 
   public start(asyncCallback: (msg: IParsedMessage<T>) => Promise<void>) {
     this.subscription.on('error', this.processError)
-    this.subscription.on('close', this.processClose)
     this.subscription.on('message', this.processMsg(asyncCallback))
     logger.info(
       `PubSub: Subscription ${this.subscriptionName} is started for topic ${this.topicName}`
@@ -108,13 +107,6 @@ export class Subscriber<T = unknown> {
     this.subscription.open()
     logger.info('Reopened subscription after error', {
       error,
-      name: this.subscription.name
-    })
-  }
-
-  private processClose = () => {
-    this.subscription.open()
-    logger.info('Reopened subscription after close', {
       name: this.subscription.name
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,32 +235,31 @@
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-1.0.2.tgz#e581aa79ff71fb6074acc1cc59e3d81bf84ce07b"
   integrity sha512-7WfV4R/3YV5T30WRZW0lqmvZy9hE2/p9MvpI34WuKa2Wz62mLu5XplGTFEMK6uTbJCLWUxTcZ4J4IyClKucE5g==
 
-"@google-cloud/pubsub@^1.0.0":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@google-cloud/pubsub/-/pubsub-1.1.5.tgz#c993a806376b42218b590bdada393ef86cc4185c"
-  integrity sha512-gFWYWkTVRgR0qPhQzUoKXu9m21P6zcJ9ORWMX+LcHqJuc1NNBpn7MTMoQTZQIof6GPUo0bTMzvkyTrq9wVTS8A==
+"@google-cloud/pubsub@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@google-cloud/pubsub/-/pubsub-1.7.2.tgz#63315a7b843ede94bc5c5cff65e16b2d0ac6b193"
+  integrity sha512-/TziioDSV4FS4wKF1sIaQ+1gvE+um83oHz1nRsZ3L87uWSoOciBjJAcocgPjqrpnW441+Nuw4w0QdSUV1Lka/g==
   dependencies:
     "@google-cloud/paginator" "^2.0.0"
     "@google-cloud/precise-date" "^1.0.0"
     "@google-cloud/projectify" "^1.0.0"
     "@google-cloud/promisify" "^1.0.0"
-    "@sindresorhus/is" "^1.0.0"
     "@types/duplexify" "^3.6.0"
     "@types/long" "^4.0.0"
     arrify "^2.0.0"
     async-each "^1.0.1"
     extend "^3.0.2"
     google-auth-library "^5.5.0"
-    google-gax "^1.7.5"
+    google-gax "^1.14.2"
     is-stream-ended "^0.1.4"
     lodash.snakecase "^4.1.1"
     p-defer "^3.0.0"
     protobufjs "^6.8.1"
 
-"@grpc/grpc-js@0.6.9":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-0.6.9.tgz#49e0b32b92b822df294cc576df169cc6112063b4"
-  integrity sha512-r1nDOEEiYmAsVYBaS4DPPqdwPOXPw7YhVOnnpPdWhlNtKbYzPash6DqWTTza9gBiYMA5d2Wiq6HzrPqsRaP4yA==
+"@grpc/grpc-js@^0.7.4":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-0.7.9.tgz#a0fae94fecfd4a44fbde496f689c2b4179407bf5"
+  integrity sha512-ihn9xWOqubMPBlU77wcYpy7FFamGo5xtsK27EAILL/eoOvGEAq29UOrqRvqYPwWfl2+3laFmGKNR7uCdJhKu4Q==
   dependencies:
     semver "^6.2.0"
 
@@ -1280,11 +1279,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sindresorhus/is@^1.0.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-1.2.0.tgz#63ce3638cb85231f3704164c90a18ef816da3fb7"
-  integrity sha512-mwhXGkRV5dlvQc4EgPDxDxO6WuMBVymGFd1CA+2Y+z5dG9MNspoQ+AWjl/Ld1MnpCL8AKbosZlDVohqcIwuWsw==
-
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -1329,6 +1323,13 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
+
+"@types/fs-extra@^8.0.1":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
+  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/glob@^7.1.1":
   version "7.1.1"
@@ -1376,6 +1377,11 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
   integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1390,6 +1396,11 @@
   version "10.17.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.4.tgz#8993a4fe3c4022fda66bf4ea660d615fc5659c6f"
   integrity sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ==
+
+"@types/node@^13.7.0":
+  version "13.13.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
+  integrity sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -3301,13 +3312,15 @@ google-auth-library@^5.0.0, google-auth-library@^5.5.0:
     jws "^3.1.5"
     lru-cache "^5.0.0"
 
-google-gax@^1.7.5:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-1.8.0.tgz#fdac69ab75ccc502e84a0f9118ec263c21b389ef"
-  integrity sha512-gDlL1mcyMSde7guPVzwpWi9V8XP+4F8UwFKoUiINEGRDNDbEj18OorL016XU0Kyt8Aizcf5dgb3q8UKegYAOmQ==
+google-gax@^1.14.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-1.15.2.tgz#a58aff43ec383f4f056f9d796e8d5e4891161eb8"
+  integrity sha512-yNNiRf9QxWpZNfQQmSPz3rIDTBDDKnLKY/QEsjCaJyDxttespr6v8WRGgU5KrU/6ZM7QRlgBAYXCkxqHhJp0wA==
   dependencies:
-    "@grpc/grpc-js" "0.6.9"
+    "@grpc/grpc-js" "^0.7.4"
     "@grpc/proto-loader" "^0.5.1"
+    "@types/fs-extra" "^8.0.1"
+    "@types/long" "^4.0.0"
     abort-controller "^3.0.0"
     duplexify "^3.6.0"
     google-auth-library "^5.0.0"
@@ -3315,7 +3328,7 @@ google-gax@^1.7.5:
     lodash.at "^4.6.0"
     lodash.has "^4.5.2"
     node-fetch "^2.6.0"
-    protobufjs "^6.8.8"
+    protobufjs "^6.8.9"
     retry-request "^4.0.0"
     semver "^6.0.0"
     walkdir "^0.4.0"
@@ -5868,7 +5881,7 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-protobufjs@^6.8.1, protobufjs@^6.8.6, protobufjs@^6.8.8:
+protobufjs@^6.8.1, protobufjs@^6.8.6:
   version "6.8.8"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
   integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==
@@ -5885,6 +5898,25 @@ protobufjs@^6.8.1, protobufjs@^6.8.6, protobufjs@^6.8.8:
     "@protobufjs/utf8" "^1.1.0"
     "@types/long" "^4.0.0"
     "@types/node" "^10.1.0"
+    long "^4.0.0"
+
+protobufjs@^6.8.9:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.9.0.tgz#c08b2bf636682598e6fabbf0edb0b1256ff090bd"
+  integrity sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" "^13.7.0"
     long "^4.0.0"
 
 protocols@^1.1.0, protocols@^1.4.0:


### PR DESCRIPTION
Sometimes our subscriptions stopped receiving messages after receiving an error event:
```
{
  fullError: "StatusError: Call cancelled (...)",
  code: 1,
  details: "Call cancelled",
  level: 500   
  message: "Error: Call cancelled (...)"   
 }
```

I'm not 100% sure this PR will fix it 😅 Unfortunately I could not pin-point the root cause. But it's at least some attempt at a workaround. I've upgraded the dependency as well, maybe it was fixed on the library side. Let's try this if you deem the change safe and then observe if we handle these errors correctly.