### PR TITLE
feat: JOIN-33238 update pubsub lib with mandatory schema in publisher factory

### DIFF
--- a/packages/pubsub/src/PublisherFactory.ts
+++ b/packages/pubsub/src/PublisherFactory.ts
@@ -12,6 +12,21 @@ export interface IPublisher<T> {
 export class PublisherFactory<TypeMap> {
   private readonly client: PubSub
 
+  constructor(private readonly logger: ILogger, private readonly avroSchemas: Record<keyof TypeMap, { writer: object, reader: object }>) {
+    this.client = new PubSub()
+  }
+
+  public getPublisher<Topic extends keyof TypeMap> (topic: Topic): IPublisher<TypeMap[Topic]> {
+    return new Publisher(topic.toString(), this.client, this.logger, this.avroSchemas[topic])
+  }
+}
+
+/**
+ * @deprecated should be used only when migration of the events/commands is not possible
+ */
+export class PublisherFactorySchemaless<TypeMap> {
+  private readonly client: PubSub
+
   constructor(private readonly logger: ILogger, private readonly avroSchemas?: Record<keyof TypeMap, { writer: object, reader: object }>) {
     this.client = new PubSub()
   }


### PR DESCRIPTION
BREAKING CHANGE: schema is now mandatory for PublisherFactory
Also added PublisherFactorySchemaless to support the cases when we can't use avro schema (like email commands)