### PR TITLE
JOIN-34014 // Add schema rollback to pubsub lib

### DIFF
--- a/packages/pubsub/src/SchemaDeployer.ts
+++ b/packages/pubsub/src/SchemaDeployer.ts
@@ -5,13 +5,12 @@ import { ILogger } from './ILogger'
 interface ISchemasForDeployment {
   forCreate: Map<string, string>,
   forNewRevision: Map<string, string>
-}
-interface ISchemaWithEvent {
-  Event: string
+  forDelete: string[]
 }
 interface IDeploymentResult {
   schemasCreated: number,
-  revisionsCreated: number
+  revisionsCreated: number,
+  schemasDeleted: number
 }
 const AVRO = 'AVRO'
 
@@ -26,38 +25,33 @@ export class SchemaDeployer {
               private readonly schemaClient: SchemaServiceClient = new SchemaServiceClient()) {
   }
   public deployAvroSchemas = async (topicsSchemaConfig: Record<string, boolean>,
-                                    topicReaderSchemas: Record<string, ReaderAvroSchema>): Promise<IDeploymentResult> => {
+                                    topicsReaderSchemas: Record<string, ReaderAvroSchema>): Promise<IDeploymentResult> => {
     if (!process.env['GCLOUD_PROJECT']) {
       throw new Error('Can\'t find GCLOUD_PROJECT env variable, please define it')
     }
-    const topicSchemasToDeploy = this.getEnabledTopicSchemas(topicsSchemaConfig, topicReaderSchemas);
-    if (topicSchemasToDeploy.size === 0) {
-      this.logger.info('Finished deployAvroSchemas, no schemas to deploy')
-      return {schemasCreated: 0, revisionsCreated: 0}
-    }
-    this.logger.info(`Found ${topicSchemasToDeploy.size} schemas enabled for deployment`)
 
-    const { forCreate, forNewRevision } = await this.aggregateTopicSchemas(topicSchemasToDeploy, topicsSchemaConfig);
-    if (forCreate.size === 0 && forNewRevision.size === 0) {
+    const { forCreate, forNewRevision, forDelete } = await this.aggregateTopicSchemas(topicsReaderSchemas, topicsSchemaConfig);
+    if (forCreate.size === 0 && forNewRevision.size === 0 && forDelete.length === 0) {
       this.logger.info('Finished deployAvroSchemas, all schemas are already deployed')
-      return {schemasCreated: 0, revisionsCreated: 0}
+      return {schemasCreated: 0, revisionsCreated: 0, schemasDeleted: 0}
 
     }
     this.logger.info(`Found ${forCreate.size} not deployed schemas, and ${forNewRevision.size} new revisions, starting deployment`)
 
     await this.createSchemas(forCreate)
     await this.createRevisions(forNewRevision)
+    await this.deleteSchemas(forDelete)
 
     this.logger.info(`Schemas deployment is finished, ${forCreate.size} schemas and ${forNewRevision.size} revisions are created`)
 
-    return {schemasCreated: forCreate.size, revisionsCreated: forNewRevision.size}
+    return {schemasCreated: forCreate.size, revisionsCreated: forNewRevision.size, schemasDeleted: forDelete.length}
 
   }
 
-  private async createRevisions(forNewRevision: Map<string, string>) {
+  private async createRevisions(forNewRevision: Map<string, string>) : Promise<void> {
     const projectName = process.env['GCLOUD_PROJECT'] as string
     for (const [topicSchema, definition] of forNewRevision) {
-      const schemaName = topicSchema + SCHEMA_NAME_SUFFIX
+      const schemaName = topicSchema
       const schemaPath = `projects/${projectName}/schemas/${schemaName}`
       await this.schemaClient.commitSchema({
         name: schemaPath, schema: {
@@ -68,55 +62,58 @@ export class SchemaDeployer {
     }
   }
 
-  private async createSchemas(forCreate: Map<string, string>) {
-    for (const [topicSchema, definition] of forCreate) {
-      const schemaName = topicSchema + SCHEMA_NAME_SUFFIX
+  private async createSchemas(forCreate: Map<string, string>): Promise<void> {
+    for (const [schemaName, definition] of forCreate) {
       await this.pubSubClient.createSchema(schemaName, AVRO, definition)
       this.logger.info(`Schema ${schemaName} is created`)
     }
   }
 
-  private getEnabledTopicSchemas(schemasConfig: Record<string, boolean>, readerSchemas: Record<string, ReaderAvroSchema>)
-    : Map<string, string> {
-    const enabledTopicsSchemas = new Map<string, string>()
-    for (const topicName in schemasConfig) {
-      const readerSchema = readerSchemas[topicName]
-      if (schemasConfig[topicName] && readerSchema) {
-        enabledTopicsSchemas.set(topicName, JSON.stringify(readerSchema.reader))
-      }
+  private async deleteSchemas(schemas: string[]): Promise<void> {
+    for (const schema of schemas) {
+      await this.schemaClient.deleteSchema({name: schema})
+      this.logger.info(`Schema ${schema} is deleted`)
     }
-    return enabledTopicsSchemas;
   }
 
-  private async aggregateTopicSchemas(topicSchemasToDeploy: Map<string, string>, topicsSchemaConfig: Record<string, boolean>)
+  private async aggregateTopicSchemas(topicSchemasToDeploy: Record<string, ReaderAvroSchema>, topicsSchemaConfig: Record<string, boolean>)
     : Promise<ISchemasForDeployment> {
-    const forCreate = new Map<string, string>(topicSchemasToDeploy)
-    const forNewRevision = new Map<string, string>()
-    for await (const schema of this.pubSubClient.listSchemas('FULL')) {
-      if (schema.type != AVRO) {
-        if (schema.name && topicsSchemaConfig[schema.name]) {
-          throw new Error(`Non avro schema exists for avro topic '${schema.name}', please remove it before starting the service`)
-        }
-      }
-      const definition = schema.definition
-      if (!definition) {
-        if (schema.name) {
-          this.logger.warn(`Schema without definition: ${schema.name}`)
-        } else {
-          this.logger.warn('Found schema without name and definition')
-        }
-        continue
-      }
-      const parsedDefinition = JSON.parse(definition) as ISchemaWithEvent
-      const eventName = parsedDefinition.Event
-      if (topicSchemasToDeploy.has(eventName)) {
-        forCreate.delete(eventName)
-        const newDefinition = topicSchemasToDeploy.get(eventName);
-        if (newDefinition && definition !== newDefinition) {
-          forNewRevision.set(eventName, newDefinition)
-        }
+    const forCreate = new Map<string, string>()
+    const forDeleteSet = new Set<string>()
+    for (const [topic, schema] of Object.entries(topicSchemasToDeploy)) {
+      if (topicsSchemaConfig[topic] === true) {
+        forCreate.set(topic + SCHEMA_NAME_SUFFIX, JSON.stringify(schema.reader))
+      } else if (topicsSchemaConfig[topic] === false) {
+        forDeleteSet.add(topic + SCHEMA_NAME_SUFFIX)
+      } else {
+        throw new Error(`Unknown value in topicsSchemaConfig ${JSON.stringify(topicsSchemaConfig)}`)
       }
     }
-    return { forCreate, forNewRevision }
+
+    const forDelete: string[] = []
+    const forNewRevision = new Map<string, string>()
+    for await (const schema of this.pubSubClient.listSchemas('FULL')) {
+      if (!schema.name) {
+        this.logger.warn('Found schema without name')
+        continue
+      }
+      if (!schema.name.endsWith(SCHEMA_NAME_SUFFIX)) {
+        continue
+      }
+      if (forCreate.has(schema.name)) {
+        if (schema.type != AVRO) {
+          throw new Error(`Non avro schema exists for avro topic '${schema.name}', please remove it before starting the service`)
+        }
+        const newDefinition = forCreate.get(schema.name);
+        if (newDefinition && schema.definition !== newDefinition) {
+          forNewRevision.set(schema.name, newDefinition)
+        }
+        forCreate.delete(schema.name)
+      }
+      if (forDeleteSet.has(schema.name)) {
+        forDelete.push(schema.name)
+      }
+    }
+    return { forCreate, forNewRevision, forDelete }
   }
 }


### PR DESCRIPTION
PR is just to save schema deletion logic if we need this later, discussed with David, it will add too much complication, and it shouldn't be really exception scenario, when you go back from avro to json, which can be handled manually