### PR TITLE
fix: JOIN-38277 add optional arrays processing before schema validation

### DIFF
--- a/packages/pubsub/src/Publisher.ts
+++ b/packages/pubsub/src/Publisher.ts
@@ -94,6 +94,9 @@ export class Publisher<T = unknown> {
 
   private logWarnIfMessageViolatesSchema(data: T): void {
     if (this.writerAvroType) {
+      if (this.optionArrayPaths && this.optionArrayPaths.length > 0) {
+        this.fieldsProcessor.findAndReplaceUndefinedOrNullOptionalArrays(data as Record<string, unknown>, this.optionArrayPaths)
+      }
       const invalidPaths: string[] = []
       if (!this.writerAvroType.isValid(data, {errorHook: path => invalidPaths.push(path.join('.'))} )) {
         this.logger?.warn(`[schema-violation] [${this.topicName}] Message violates writer avro schema`, { payload: data, metadata: this.avroMessageMetadata, invalidPaths })


### PR DESCRIPTION
This update expands the capacity of the `logWarnIfMessageViolatesSchema` method in `Publisher.ts` to handle optional array paths. It specifically adds logic that finds and replaces any undefined or null optional arrays before the Avro schema validation takes place